### PR TITLE
Fix syntax errors in examples in README and POD (closes #1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ AnyEvent::Mattermost - AnyEvent module for interacting with the Mattermost APIs
 
     $mconn->on('posted' => sub {
         my ($self, $message) = @_;
-        printf "<%s> %s\n", $message->{data}{sender_name}, $message->{data}{post}";
+        printf "<%s> %s\n", $message->{data}{sender_name}, $message->{data}{post};
     });
 
     $mconn->start;

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ AnyEvent::Mattermost - AnyEvent module for interacting with the Mattermost APIs
 
     my $host = "https://mattermost.example.com/";
     my $team = "awesome-chat";
-    my $user = "janedoe@example.com";
+    my $user = "janedoe\@example.com";
     my $pass = "foobar123";
 
     my $cond = AnyEvent->condvar;

--- a/lib/AnyEvent/Mattermost.pm
+++ b/lib/AnyEvent/Mattermost.pm
@@ -29,7 +29,7 @@ use Try::Tiny;
 
     my $host = "https://mattermost.example.com/";
     my $team = "awesome-chat";
-    my $user = "janedoe@example.com";
+    my $user = "janedoe\@example.com";
     my $pass = "foobar123";
 
     my $cond = AnyEvent->condvar;
@@ -37,7 +37,7 @@ use Try::Tiny;
 
     $mconn->on('posted' => sub {
         my ($self, $message) = @_;
-        printf "<%s> %s\n", $message->{data}{sender_name}, $message->{data}{post}";
+        printf "<%s> %s\n", $message->{data}{sender_name}, $message->{data}{post};
     });
 
     $mconn->start;


### PR DESCRIPTION
As per #1:

* Removed extra double quote in "posted" hook example.
* Escaped `@` in e-mail address in connection example.